### PR TITLE
Return instance from express.listen() so server can be close()d later

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,13 +215,15 @@ var appServer = function(config) {
 	}
 		// Start the server listening
 		config.port = config.port || process.env.port || 80;
-		self.express.listen(config.port);
+		var instance = self.express.listen(config.port);
 		self.log("Listening on HTTP port "+config.port);
 		
 		// Run the post() method if defined
 		if (typeof config.post=="function") {
 			config.post(self);
 		}
+		
+		return instance;
 	};
 	
 	return self;


### PR DESCRIPTION
Gulp tasks hang as a result of the server running. Need to be able to start an instance of the server and close() it when the task is complete.

For example:
```javascript
var server = require('../../server');

gulp.task('test-local', 'Run unit tests against local server **', function () {
    var instance = server.start();

    var result = gulp.src(filePaths.unitTestFiles)
        .pipe(mocha({reporter: 'progress'}))
        .on('end', function () {
            instance.close();
        });
    return result;
});
```