### PR TITLE
Add support for alexa-verifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ node_modules
 Network Trash Folder
 Temporary Items
 .apdisk
+/.idea

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ require('alexa-app-server').start({
     // By default, some information is logged with console.log(), which can be disabled
     log : true,
     
+    // This will add verification for alexa requests as require by the alexa certification
+    // process. Provied by alexa-verifier
+    verify: false,
+    
     // The pre() method is called after the express server has been instantiated, 
 	// but before and Alexa Apps have been loaded. It is passed the AlexaAppServer 
 	// object itself.

--- a/index.js
+++ b/index.js
@@ -14,14 +14,14 @@ var appServer = function(config) {
 	config = config || {};
 	var server_root = config.server_root || '';
 	self.apps = {};
-	
+
 	self.log = function(msg) {
 		if (config.log!==false) {
 			console.log(msg);
 		}
 	};
 	self.error = function(msg) { console.log(msg); };
-	
+
 	// Configure hotswap to watch for changes and swap out module code
 	hotswap.on('swap', function(filename) {
 		self.log("hotswap reloaded "+filename);
@@ -39,19 +39,19 @@ var appServer = function(config) {
 		};
 		app_directories(app_dir).forEach(function(dir) {
 			var package_json = path.join(app_dir,dir,"/package.json");
-			if (!fs.existsSync(package_json) || !fs.statSync(package_json).isFile()) { 
+			if (!fs.existsSync(package_json) || !fs.statSync(package_json).isFile()) {
 				self.log("   package.json not found in directory "+dir);
-				return; 
+				return;
 			}
 			var pkg = JSON.parse(fs.readFileSync(package_json, 'utf8'));
-			if (!pkg || !pkg.main || !pkg.name) { 
+			if (!pkg || !pkg.main || !pkg.name) {
 				self.log("   Failed to load "+package_json);
-				return; 
+				return;
 			}
 			var main = fs.realpathSync( path.join(app_dir,dir,pkg.main) );
-			if (!fs.existsSync(main) || !fs.statSync(main).isFile()) { 
+			if (!fs.existsSync(main) || !fs.statSync(main).isFile()) {
 				self.log("   main file not found for app ["+pkg.name+"]: "+main);
-				return; 
+				return;
 			}
 			try {
 				var app = require(main);
@@ -61,7 +61,7 @@ var appServer = function(config) {
 					self.log("   App ["+pkg.name+"] is not an instance of alexa-app");
 					return;
 				}
-				
+
 				// Extract Alexa-specific attributes from package.json, if they exist
 				if (typeof pkg.alexa=="object") {
 					app.id = pkg.alexa.applicationId;
@@ -75,26 +75,26 @@ var appServer = function(config) {
 					self.express.use(endpoint, function(req, res, next)
 					{
 						req.verified = false;
-                        if (!req.headers.signaturecertchainurl) {
-                            return next();
-                        }
+						if (!req.headers.signaturecertchainurl) {
+							return next();
+						}
 
-                        var cert_url = req.headers.signaturecertchainurl;
-                        var signature = req.headers.signature;
-                        var requestBody = req.rawBody;
-                        verifier(cert_url, signature, requestBody, function(er) {
-                            if (er) {
-                                res.status(401).json({ status: 'failure', reason: er });
-                            } else {
-                                req.verified = true;
-                                next();
-                            }
-                        });
+						var cert_url = req.headers.signaturecertchainurl;
+						var signature = req.headers.signature;
+						var requestBody = req.rawBody;
+						verifier(cert_url, signature, requestBody, function(er) {
+							if (er) {
+								res.status(401).json({ status: 'failure', reason: er });
+							} else {
+								req.verified = true;
+								next();
+							}
+						});
 					});
 				}
 				self.express.post(endpoint,function(req,res) {
 					if (config.verify && !req.verified) {
-                        res.status(401).json({ status: 'failure', reason: er });
+						res.status(401).json({ status: 'failure', reason: er });
 					}
 					var json = req.body, response_json;
 					// preRequest may return altered request JSON, or undefined, or a Promise
@@ -132,7 +132,7 @@ var appServer = function(config) {
 						}
 					});
 				}
-				
+
 				self.log("   Loaded app ["+pkg.name+"] at endpoint: "+endpoint);
 			}
 			catch(e) {
@@ -159,7 +159,7 @@ var appServer = function(config) {
 			}
 		});
 	};
-	
+
 	self.start = function() {
 		// Instantiate up the server
 		self.express = express();
@@ -167,23 +167,23 @@ var appServer = function(config) {
 
 		//We need the rawBody for request verification
 		self.express.use(function(req, res, next)
-        {
-            // mark the request body as already having been parsed so it's ignored by
-            // other body parser middlewares
-            req._body = true;
-            req.rawBody = '';
-            req.on('data', function(data) {
-                return req.rawBody += data;
-            });
-            req.on('end', function() {
-                try {
-                    req.body = JSON.parse(req.rawBody);
-                } catch (error) {
-                    req.body = {};
-                }
-                next();
-            });
-        });
+		{
+			// mark the request body as already having been parsed so it's ignored by
+			// other body parser middlewares
+			req._body = true;
+			req.rawBody = '';
+			req.on('data', function(data) {
+				return req.rawBody += data;
+			});
+			req.on('end', function() {
+				try {
+					req.body = JSON.parse(req.rawBody);
+				} catch (error) {
+					req.body = {};
+				}
+				next();
+			});
+		});
 		self.express.set('views', path.join(__dirname,'views'));
 		self.express.set('view engine', 'ejs');
 
@@ -191,20 +191,20 @@ var appServer = function(config) {
 		if (typeof config.pre=="function") {
 			config.pre(self);
 		}
-		
+
 		// Serve static content
 		var static_dir = path.join(server_root,config.public_html || 'public_html');
-		if (fs.existsSync(static_dir) && fs.statSync(static_dir).isDirectory()) { 
+		if (fs.existsSync(static_dir) && fs.statSync(static_dir).isDirectory()) {
 			self.log("Serving static content from: "+static_dir);
 			self.express.use(express.static(static_dir));
 		}
 		else {
 			self.log("Not serving static content because directory ["+static_dir+"] does not exist");
 		}
-		
+
 		// Find any server-side processing modules and let them hook in
 		var server_dir = path.join(server_root,config.server_dir || 'server');
-		if (fs.existsSync(server_dir) && fs.statSync(server_dir).isDirectory()) { 
+		if (fs.existsSync(server_dir) && fs.statSync(server_dir).isDirectory()) {
 			self.log("Loading server-side modules from: "+server_dir);
 			self.load_server_modules(server_dir);
 		}
@@ -214,63 +214,63 @@ var appServer = function(config) {
 
 		// Find and load alexa-app modules
 		var app_dir = path.join(server_root,config.app_dir || 'apps');
-		if (fs.existsSync(app_dir) && fs.statSync(app_dir).isDirectory()) { 
+		if (fs.existsSync(app_dir) && fs.statSync(app_dir).isDirectory()) {
 			self.log("Loading apps from: "+app_dir);
 			self.load_apps(app_dir,config.app_root || '/alexa/');
 		}
 		else {
 			self.log("Apps not loaded because directory ["+app_dir+"] does not exist");
 		}
-		
+
 		if(config.httpsEnabled == true) {
 			self.log("httpsEnabled is true. Reading HTTPS config");
 
 			if(config.privateKey != undefined && config.certificate != undefined && config.httpsPort != undefined) { //Ensure that all of the needed properties are set
 				var privateKeyFile = 'sslcert/' + config.privateKey;
 				var certificateFile = 'sslcert/' + config.certificate;
-				
+
 				if(fs.existsSync(privateKeyFile) && fs.existsSync(certificateFile)) { //Make sure the key and cert exist.
-					
+
 					var privateKey  = fs.readFileSync(privateKeyFile, 'utf8');
 					var certificate = fs.readFileSync(certificateFile  , 'utf8');
-			
+
 						if(privateKey != undefined && certificate != undefined) {
 							var credentials = {key: privateKey, cert: certificate};
-								
+
 									try { //The line below can fail it the certs were generated incorrectly. But we can continue startup without HTTPS
-								  	https.createServer(credentials, self.express).listen(config.httpsPort); //create the HTTPS server 
-								  	self.log("Listening on HTTPS port " + config.httpsPort);
+									https.createServer(credentials, self.express).listen(config.httpsPort); //create the HTTPS server
+									self.log("Listening on HTTPS port " + config.httpsPort);
 								}catch(error) {
 									self.log("Failed to listen via HTTPS Error: " + error);
 								}
 						} else {
 						self.log("Failed to load privateKey or certificate from /sslcert. HTTPS will not be enabled");
-				
-						} 
-			
+
+						}
+
 				} else {
 				self.log("privateKey: '" + config.privateKey +  "' or certificate: '" + config.certificate + "' do not exist in /sslcert. HTTPS will not be enabled");
-		
-				} 	
+
+				}
 		} else {
 			self.log("privatekey, httpsPort, or certificate paramater not set in config. HTTPS will not be enabled");
-				
+
 		}
-		
+
 	}
 		// Start the server listening
 		config.port = config.port || process.env.port || 80;
 		var instance = self.express.listen(config.port);
 		self.log("Listening on HTTP port "+config.port);
-		
+
 		// Run the post() method if defined
 		if (typeof config.post=="function") {
 			config.post(self);
 		}
-		
+
 		return instance;
 	};
-	
+
 	return self;
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Matt Kruse",
   "dependencies": {
     "alexa-app": "^2.1.0",
+    "alexa-verifier": "0.0.5",
     "bluebird": "^2.9.34",
     "body-parser": "~1.0.1",
     "ejs": "~0.7.1",


### PR DESCRIPTION
This patch adds a config option which adds support for alexa-verifier, which verifies that requests are legitimately coming from the Amazon server. This is a requirement for app validation.